### PR TITLE
Fix Clang errors and warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,13 @@ CC=gcc
 CFLAGS=-O3 -Wall -std=gnu99
 LDFLAGS=-lm
 
+HEADERS = ohgodatool-common.h ohgodatool.h vbios-tables.h
+SOURCES = ohgodatool-args.c ohgodatool-utils.c ohgodatool.c
+
 all: ohgodatool
 
-ohgodatool: ohgodatool-args.c ohgodatool-utils.c ohgodatool.c
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+ohgodatool: $(SOURCES) $(HEADERS)
+	$(CC) $(CFLAGS) -o $@ $(SOURCES) $(LDFLAGS)
 
 install: all
 	cp -v ohgodatool /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS=-lm
 
 all: ohgodatool
 
-ohgodatool: ohgodatool-args.c ohgodatool-utils.c ohgodatool.c ohgodatool-common.h ohgodatool.h vbios-tables.h
+ohgodatool: ohgodatool-args.c ohgodatool-utils.c ohgodatool.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 install: all

--- a/ohgodatool-args.c
+++ b/ohgodatool-args.c
@@ -24,7 +24,7 @@ void PrintUsage(char *BinName)
 	printf("\t--show-fanspeed\n\t--show-temp\n");
 }
 
-#define NEXT_ARG_CHECK() do { if(i == (argc - 1)) { printf("Argument \"%s\" requires a parameter.\n"); return(false); } } while(0)
+#define NEXT_ARG_CHECK() do { if(i == (argc - 1)) { printf("Argument \"%s\" requires a parameter.\n", argv[i]); return(false); } } while(0)
 
 bool ParseCmdLine(ArgsObj *Args, int argc, char **argv)
 {

--- a/ohgodatool.c
+++ b/ohgodatool.c
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
 	
 	if(BytesRead != PPTblSize)
 	{
-		printf("Unable to read entire PowerPlay table. (read %zu, size was %zu)\n", BytesRead, PPTblSize);
+		printf("Unable to read entire PowerPlay table. (read %u, size was %u)\n", (unsigned)BytesRead, (unsigned)PPTblSize);
 		free(PPTblBuf);
 		fclose(PPFile);
 		return(-1);

--- a/ohgodatool.c
+++ b/ohgodatool.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
 	uint8_t *PPTblBuf;
 	size_t BytesRead;
 	ArgsObj Config;
-	int PPTblSize;
+	size_t PPTblSize;
 	FILE *PPFile;
 	
 	if(!ParseCmdLine(&Config, argc, argv)) return(-1);
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
 	
 	if(BytesRead != PPTblSize)
 	{
-		printf("Unable to read entire PowerPlay table. (read %d, size was %d)\n", BytesRead, PPTblSize);
+		printf("Unable to read entire PowerPlay table. (read %zu, size was %zu)\n", BytesRead, PPTblSize);
 		free(PPTblBuf);
 		fclose(PPFile);
 		return(-1);


### PR DESCRIPTION
- Don't list headers as input files for compilation.
- `printf` typos.
